### PR TITLE
Improve DICOM writer error handling

### DIFF
--- a/gateway/app_sdk_io.py
+++ b/gateway/app_sdk_io.py
@@ -2,41 +2,50 @@ from pathlib import Path
 from typing import Dict, Any, List
 
 
-def write_dicom_sr(study_dir: str, impression: str, findings: List[str], structured: Dict[str, Any], provenance: Dict[str, Any], out_dir: str) -> str:
+def write_dicom_sr(
+    study_dir: str,
+    impression: str,
+    findings: List[str],
+    structured: Dict[str, Any],
+    provenance: Dict[str, Any],
+    out_dir: str,
+) -> str:
     """Format report text and write a DICOM SR via MONAI Deploy App SDK.
 
-    Falls back to writing a plain text file with .dcm extension if the SDK is
-    not available. Returns the path to the written SR file."""
+    Raises ``RuntimeError`` if the MONAI Deploy operator is unavailable or fails
+    to generate an SR."""
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
     text = _format_sr_text(impression, findings, structured, provenance)
 
     try:
         from monai.deploy.operators import DICOMTextSRWriterOperator
-        op = DICOMTextSRWriterOperator(app=None, output_folder=out)
-        return _run_sr_writer(op, study_dir, text)
-    except Exception:
-        # Fallback: just write text to a fake DICOM file
-        sr = out / "report_sr.dcm"
-        sr.write_text(text)
-        return str(sr)
+    except Exception as e:  # pragma: no cover - import guarded
+        raise RuntimeError(
+            "DICOMTextSRWriterOperator is not available. Install monai-deploy-app-sdk."
+        ) from e
+
+    op = DICOMTextSRWriterOperator(app=None, output_folder=out)
+    return _run_sr_writer(op, study_dir, text)
 
 
 def write_dicom_seg(study_dir: str, seg_nifti: str, out_dir: str) -> str:
     """Write a DICOM SEG from a NIfTI mask using MONAI Deploy App SDK.
 
-    Falls back to copying the NIfTI path to a .dcm placeholder."""
+    Raises ``RuntimeError`` if the MONAI Deploy operator is unavailable or fails
+    to generate a SEG."""
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
 
     try:
         from monai.deploy.operators import DICOMSegmentationWriterOperator
-        op = DICOMSegmentationWriterOperator(app=None, output_folder=out, segment_descriptions=["Lesion"])
-        return _run_seg_writer(op, study_dir, seg_nifti)
-    except Exception:
-        seg = out / "seg.dcm"
-        Path(seg).write_text("segmentation placeholder")
-        return str(seg)
+    except Exception as e:  # pragma: no cover - import guarded
+        raise RuntimeError(
+            "DICOMSegmentationWriterOperator is not available. Install monai-deploy-app-sdk."
+        ) from e
+
+    op = DICOMSegmentationWriterOperator(app=None, output_folder=out, segment_descriptions=["Lesion"])
+    return _run_seg_writer(op, study_dir, seg_nifti)
 
 
 def _format_sr_text(impression: str, findings: List[str], structured: Dict[str, Any], provenance: Dict[str, Any]) -> str:
@@ -49,29 +58,32 @@ def _format_sr_text(impression: str, findings: List[str], structured: Dict[str, 
 
 
 def _run_sr_writer(op, study_dir: str, text: str) -> str:
-    """Helper to invoke DICOMTextSRWriterOperator."""
+    """Helper to invoke :class:`DICOMTextSRWriterOperator`.
+
+    Returns the path to the generated SR and surfaces any errors from the
+    underlying operator."""
     try:
         op(study_list=[study_dir], text=text)
-        outputs = sorted(Path(op.output_folder).glob("*.dcm"))
-        if outputs:
-            return str(outputs[0])
-    except Exception:
-        pass
-    # Fallback
-    sr = Path(op.output_folder) / "report_sr.dcm"
-    sr.write_text(text)
-    return str(sr)
+    except Exception as e:
+        raise RuntimeError("Failed to write DICOM SR") from e
+
+    outputs = sorted(Path(op.output_folder).glob("*.dcm"))
+    if not outputs:
+        raise RuntimeError("DICOM SR writer produced no output")
+    return str(outputs[0])
 
 
 def _run_seg_writer(op, study_dir: str, seg_nifti: str) -> str:
-    """Helper to invoke DICOMSegmentationWriterOperator."""
+    """Helper to invoke :class:`DICOMSegmentationWriterOperator`.
+
+    Returns the path to the generated SEG and surfaces any errors from the
+    underlying operator."""
     try:
         op(study_list=[study_dir], seg_image=seg_nifti)
-        outputs = sorted(Path(op.output_folder).glob("*.dcm"))
-        if outputs:
-            return str(outputs[0])
-    except Exception:
-        pass
-    seg = Path(op.output_folder) / "seg.dcm"
-    Path(seg).write_text("segmentation placeholder")
-    return str(seg)
+    except Exception as e:
+        raise RuntimeError("Failed to write DICOM SEG") from e
+
+    outputs = sorted(Path(op.output_folder).glob("*.dcm"))
+    if not outputs:
+        raise RuntimeError("DICOM SEG writer produced no output")
+    return str(outputs[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 monai
+monai-deploy-app-sdk
 nibabel
 pydicom
 torch


### PR DESCRIPTION
## Summary
- add monai-deploy-app-sdk requirement
- raise errors from DICOM SR/SEG writers instead of silent fallbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c081b579508328a3b393155c3b9932