### PR TITLE
Add drag-and-drop upload and enhance result display

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1,0 +1,48 @@
+.drop-zone {
+  border: 2px dashed #ccc;
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.drop-zone.over {
+  border-color: #0ea5e9;
+  background-color: #f0f9ff;
+}
+
+.pill {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  color: #fff;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.pill.normal {
+  background-color: #16a34a;
+}
+
+.pill.abnormal {
+  background-color: #dc2626;
+}
+
+.result-status {
+  display: flex;
+  align-items: center;
+}
+
+.thumbnails {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.thumbnails img {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,10 +1,38 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { uploadZip, startAnalyze, getResult } from './api';
+import './App.css';
+
+function DropZone({ onFile, onBrowse, fileName }: { onFile: (f: File) => void; onBrowse: () => void; fileName?: string }) {
+  const [over, setOver] = useState(false);
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) onFile(f);
+    setOver(false);
+  };
+  return (
+    <div
+      className={`drop-zone ${over ? 'over' : ''}`}
+      onDragOver={e => {
+        e.preventDefault();
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={handleDrop}
+      onClick={onBrowse}
+    >
+      {fileName || 'Drag & drop study zip here or click to browse'}
+    </div>
+  );
+}
 
 export default function App() {
   const [file, setFile] = useState<File | null>(null);
   const [jobId, setJobId] = useState('');
   const [result, setResult] = useState<any>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const handleFile = (f: File | null) => setFile(f);
 
   const handleUpload = async () => {
     if (file) {
@@ -36,7 +64,13 @@ export default function App() {
     <div style={{ display: 'flex', gap: '2rem', padding: '1rem' }}>
       <div style={{ flex: 1 }}>
         <h2>Upload Study</h2>
-        <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+        <DropZone onFile={handleFile} onBrowse={() => fileInput.current?.click()} fileName={file?.name} />
+        <input
+          type="file"
+          ref={fileInput}
+          style={{ display: 'none' }}
+          onChange={e => handleFile(e.target.files?.[0] || null)}
+        />
         <div>
           <button onClick={handleUpload} disabled={!file}>Upload</button>
           <button onClick={handleAnalyze} disabled={!jobId}>Analyze</button>
@@ -48,15 +82,25 @@ export default function App() {
           <div>
             <h2>Impression</h2>
             <p>{result.impression}</p>
-            <p><strong>{result.normal ? 'Normal' : 'Abnormal'}</strong> ({Math.round(result.confidence * 100)}%)</p>
+            <p className="result-status">
+              <span className={`pill ${result.normal ? 'normal' : 'abnormal'}`}>{result.normal ? 'Normal' : 'Abnormal'}</span>
+              {new Intl.NumberFormat(undefined, { style: 'percent', maximumFractionDigits: 1 }).format(result.confidence)}
+            </p>
             <ul>
               {result.findings.map((f: string, i: number) => (
                 <li key={i}>{f}</li>
               ))}
             </ul>
+            {Array.isArray(result.downloads?.thumbnails) && result.downloads.thumbnails.length > 0 && (
+              <div className="thumbnails">
+                {result.downloads.thumbnails.map((url: string, i: number) => (
+                  <img key={i} src={url} alt={`thumbnail-${i}`} />
+                ))}
+              </div>
+            )}
             <div>
-              <a href={result.downloads.dicom_sr}>DICOM SR</a><br/>
-              {result.downloads.dicom_seg && <a href={result.downloads.dicom_seg}>DICOM SEG</a>}<br/>
+              <a href={result.downloads.dicom_sr}>DICOM SR</a><br />
+              {result.downloads.dicom_seg && <a href={result.downloads.dicom_seg}>DICOM SEG</a>}<br />
               <a href={result.downloads.json}>JSON</a>
             </div>
             <p style={{ marginTop: '1rem' }}>AI-generated. Research use only.</p>


### PR DESCRIPTION
## Summary
- Add drag-and-drop file upload zone with hover styling
- Show classification as colored pill with percent-formatted confidence
- Display optional result thumbnails

## Testing
- `npm run build` *(fails: @vitejs/plugin-react resolved to an ESM file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c081bdf0b08328b397f0a8e9741c07