### PR TITLE
Add standalone desktop GUI for MRI analysis demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ artifacts are stored under `/data/jobs/<job_id>/` on the gateway container.
 > **Note**: The heavy AI models are stubbed for development purposes; the code is
 > structured so real models can be integrated later.
 
+## Desktop application
+
+For a quick demonstration without running the full stack, a lightweight desktop
+GUI is provided.  It calls into the same agent logic with stubbed AI models so
+that a second-opinion report can be generated entirely offline.
+
+```bash
+pip install -r requirements.txt
+python desktop_app.py
+```
+
+Use the *Analyze* button to process a selected MRI study folder.  The interface
+reports whether the study appears normal or abnormal along with an impression
+and bullet list of findings.
+
 ## Development
 
 Install Python dependencies and run tests:

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -1,0 +1,76 @@
+"""Simple desktop GUI for the MRI Auto-Report demo.
+
+This application provides a minimal yet functional interface for generating a
+second-opinion report from a brain MRI study.  It calls into the existing agent
+logic with stubbed AI models so it can run entirely offline as a demonstration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import PySimpleGUI as sg
+
+from agent.server import AnalyzeReq, analyze
+
+
+# ---------------------------------------------------------------------------
+# Application logic
+# ---------------------------------------------------------------------------
+
+def _run_analysis(study_dir: str) -> dict:
+    """Execute the analysis pipeline and return the result structure."""
+
+    req = AnalyzeReq(study_dir=study_dir, tools=[])
+    return analyze(req)
+
+
+# ---------------------------------------------------------------------------
+# GUI setup
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    sg.theme("SystemDefault")
+
+    layout = [
+        [sg.Text("MRI study folder"), sg.Input(key="-DIR-"), sg.FolderBrowse()],
+        [sg.Button("Analyze", key="-RUN-")],
+        [sg.Text("", key="-STATUS-")],
+        [sg.Multiline(size=(80, 20), key="-OUT-", disabled=True)],
+    ]
+
+    window = sg.Window("MRI Second Opinion Demo", layout)
+
+    while True:
+        event, values = window.read()
+        if event == sg.WINDOW_CLOSED:
+            break
+        if event == "-RUN-":
+            study_dir = values.get("-DIR-", "")
+            if not study_dir or not Path(study_dir).exists():
+                sg.popup_error("Please choose a valid folder containing the study")
+                continue
+            window["-STATUS-"].update("Analyzing...")
+            window.refresh()
+            try:
+                res = _run_analysis(study_dir)
+            except Exception as e:  # pragma: no cover - GUI runtime
+                window["-STATUS-"].update("Analysis failed")
+                sg.popup_error("Analysis failed", str(e))
+                continue
+            window["-STATUS-"].update(
+                "Normal" if res.get("normal") else "Abnormal"
+            )
+            out = (
+                f"Study: {study_dir}\n"
+                f"Confidence: {res.get('confidence', 0.0):.2f}\n\n"
+                f"Impression:\n{res.get('impression', '')}\n\n"
+                "Findings:\n" + "\n".join(f"- {f}" for f in res.get("findings", []))
+            )
+            window["-OUT-"].update(out)
+
+    window.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 requests
 python-multipart
 scipy
+PySimpleGUI


### PR DESCRIPTION
## Summary
- Add `desktop_app.py` providing a PySimpleGUI desktop interface so the demo can be driven entirely through the GUI
- Document desktop workflow in README and note new dependency
- Include PySimpleGUI in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19346bc288328965fd9a36b564739