### PR TITLE
Run MRI analysis locally within desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 # MRI Auto-Report (Normal vs Abnormal)
 
-This repository implements a minimal end-to-end pipeline for generating a
-radiology report from an uploaded brain MRI study. It now features a small
-local Python GUI for interacting with the system.
+This repository implements a minimal end-to-end pipeline for generating a radiology report from an uploaded brain MRI study. The entire pipeline now runs locally as a standalone Python desktop application built with Tkinter—no separate web services are required.
 
-* **Local GUI (Tkinter)** – desktop app for uploading a study and displaying the
-  result.
-* **Gateway (FastAPI)** – orchestrates upload, analysis and packaging of DICOM
-  SR/SEG outputs.
-* **Agent Service** – wraps the MONAI Radiology Agent Framework and VILA-M3 to
-  draft the report and coordinate expert tools.
-* **Expert Hub** – microservice hosting segmentation models such as BraTS.
+* **Desktop App (Tkinter)** – upload a study, run analysis and view results locally.
 
-The abnormality volume threshold can be customized via the
-`ABNORMAL_THRESHOLD_CC` environment variable shared by the gateway and agent.
+The abnormality volume threshold can be customized via the `ABNORMAL_THRESHOLD_CC` environment variable.
 
-A `docker-compose` file is provided to launch all services together. Each job's
-artifacts are stored under `/data/jobs/<job_id>/` on the gateway container.
-
-> **Note**: The heavy AI models are stubbed for development purposes; the code is
-> structured so real models can be integrated later.
+> **Note**: The heavy AI models are stubbed for development purposes; the code is structured so real models can be integrated later.
 
 ## Development
 
@@ -28,12 +15,6 @@ Install Python dependencies and run tests:
 ```bash
 pip install -r requirements.txt
 pytest
-```
-
-To run the full stack with Docker:
-
-```bash
-docker compose up --build
 ```
 
 Launch the desktop interface:

--- a/desktop_pipeline.py
+++ b/desktop_pipeline.py
@@ -1,0 +1,91 @@
+"""
+Local end-to-end analysis pipeline for the desktop application.
+
+Combines the previous gateway and agent functionality into a single
+function that operates purely on local files.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict
+
+from agent.vila_loader import load_vila, run_vlm
+from agent.server import render_prompt, _impression, _bullets
+from gateway.app_sdk_io import write_dicom_sr, write_dicom_seg
+from gateway.settings import ABNORMAL_THRESHOLD_CC
+
+
+def analyze_zip(zip_path: str, anatomy: str = "brain") -> Dict[str, Any]:
+    """Run the MRI analysis pipeline on a ZIP archive.
+
+    The archive is extracted into a temporary working directory, BraTS
+    segmentation is performed locally, a VLM drafts the report and DICOM SR/SEG
+    files are optionally written.  Returns a dictionary mirroring the previous
+    gateway response structure.
+    """
+    with TemporaryDirectory() as tmpdir:
+        job = Path(tmpdir)
+        dcm = job / "dicom"
+        work = job / "work"
+        out = job / "out"
+        for p in (dcm, work, out):
+            p.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            for member in zf.namelist():
+                member_path = (dcm / member).resolve()
+                if not str(member_path).startswith(str(dcm.resolve())):
+                    raise ValueError("invalid file path in zip")
+                zf.extract(member, dcm)
+
+        from experts.runners.brats_runner import run_brats
+
+        seg_path, vol_cc, n_lesions = run_brats(str(dcm), str(work / "brats_seg.nii.gz"))
+        stats = {"lesion_volume_cc": vol_cc, "num_lesions": n_lesions}
+
+        try:
+            vlm = load_vila()
+        except Exception:
+            vlm = None
+        prompt = render_prompt(anatomy, stats, {})
+        text, prob = run_vlm(vlm, prompt)
+        abnormal = (stats.get("lesion_volume_cc", 0) or 0) > ABNORMAL_THRESHOLD_CC
+
+        impression = _impression(text, abnormal)
+        findings = _bullets(text)
+
+        sr_path = seg_dcm = None
+        try:
+            sr_path = write_dicom_sr(
+                study_dir=str(dcm),
+                impression=impression,
+                findings=findings,
+                structured=stats,
+                provenance={
+                    "vlm": {"name": "VILA-M3", "ckpt": "<fill>"},
+                    "tools": [{"name": "brats", "version": "<fill>"}]
+                },
+                out_dir=str(out),
+            )
+            if abnormal and seg_path:
+                seg_dcm = write_dicom_seg(
+                    study_dir=str(dcm), seg_nifti=seg_path, out_dir=str(out)
+                )
+        except Exception:
+            sr_path = seg_dcm = None
+
+        result = {
+            "normal": not abnormal,
+            "confidence": max(prob, 0.5),
+            "impression": impression,
+            "findings": findings,
+            "structured": stats,
+            "downloads": {
+                "dicom_sr": sr_path,
+                "dicom_seg": seg_dcm,
+            },
+        }
+        return result

--- a/gui/app.py
+++ b/gui/app.py
@@ -1,9 +1,9 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox
-import requests
 import json
 
-GATEWAY_URL = "http://localhost:8000"
+from desktop_pipeline import analyze_zip
+
 
 class App(tk.Tk):
     def __init__(self):
@@ -30,14 +30,7 @@ class App(tk.Tk):
             messagebox.showerror("Error", "Please select a ZIP file")
             return
         try:
-            with open(path, "rb") as f:
-                resp = requests.post(f"{GATEWAY_URL}/upload", files={"study": ("study.zip", f, "application/zip")})
-            resp.raise_for_status()
-            job_id = resp.json()["job_id"]
-
-            resp = requests.post(f"{GATEWAY_URL}/analyze/{job_id}", json={"anatomy": "brain"})
-            resp.raise_for_status()
-            data = resp.json()
+            data = analyze_zip(path)
             self.output.delete("1.0", tk.END)
             self.output.insert(tk.END, json.dumps(data, indent=2))
         except Exception as e:


### PR DESCRIPTION
## Summary
- Add `desktop_pipeline.analyze_zip` to execute the full analysis locally without HTTP services
- Update Tkinter GUI to call local pipeline directly
- Simplify README to describe standalone desktop workflow

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e8be45508328aa14db0cd0810448